### PR TITLE
[fix] Updated dependencies and removed deprecated configuration

### DIFF
--- a/conf/homeassistant_conf_files/configuration.yaml
+++ b/conf/homeassistant_conf_files/configuration.yaml
@@ -38,9 +38,6 @@ http:
   # If legacy_api_password is active as auth_provider 
   #api_password: !secret http_password
 
-# Show links to resources in log and frontend
-introduction:
-
 # Enables the frontend
 frontend:
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,7 +3,7 @@
 #
 
 # Package dependencies
-PKG_DEPENDENCIES="python3 python3-venv python3-pip"
+PKG_DEPENDENCIES="python3 python3-venv python3-pip libffi-dev libssl-dev"
 
 # Check if directory/file already exists (path in argument)
 myynh_check_path () {


### PR DESCRIPTION
I encountered two issues while installing homeassistant_ynh on a Raspberry Pi:

1. Some dependencies were missing: `libffi-dev libssl-dev`
2. After installation, hass was complaining about `introduction:` being deprecated in `configuration.yaml

Here is a fix for both issues. I would suggest to merge it into a `testing` branch first.