### PR TITLE
Fix restore

### DIFF
--- a/check_process
+++ b/check_process
@@ -17,7 +17,7 @@
 		multi_instance=0
 		port_already_use=1
 		change_url=1
-		actions=1
+		actions=0
 		config_panel=0
 ;;; Options
 	Notification=all

--- a/conf/homeassistant_conf_files/bin/ynh_ldap-auth.sh
+++ b/conf/homeassistant_conf_files/bin/ynh_ldap-auth.sh
@@ -48,7 +48,7 @@ log() {
 
 # Check permission of ynh user.
 ynh_user_app_permission() {
-	access=$(cat "/etc/ssowat/conf.json" | jq 'def IN(s): . as $in | first(if (s == $in) then true else empty end) ; .permissions["homeassistant.main"].users as $f | '\"$username\"' | IN($f[])')
+	access=$(cat "/etc/ssowat/conf.json" | jq ".permissions.\"homeassistant.main\".users | index(\"$username\")")
 	[ ! -z "$access" ] && return 1
 	return 0
 }

--- a/scripts/backup
+++ b/scripts/backup
@@ -16,17 +16,17 @@ domain=$(ynh_app_setting_get --app="$app" --key=domain)
 final_path="/opt/yunohost/$app"
 home_path="/home/$app"
 
-ynh_script_progression --message="Storing the python version in settings..."
+ynh_print_info --message="Storing the python version in settings..."
 # store python version
 python=$(cat "$final_path/bin/python3" --version | cut -d ' ' -f 2)
 ynh_app_setting_set --app="$app" --key=python --value="$python"
 
 # backup source & conf files
-ynh_script_progression --message="Backuping the app, datas & ystem files..."
+ynh_print_info  --message="Declaring files to be backed up..."
 ynh_backup --src_path="$final_path"
 ynh_backup --src_path="$home_path"
 ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_backup --src_path="/etc/sudoers.d/$app"
 ynh_backup --src_path="/etc/systemd/system/$app@$app.service"
 
-ynh_script_progression --message="Backup of $app completed" --last
+ynh_print_info --message="Backup of $app completed"

--- a/scripts/restore
+++ b/scripts/restore
@@ -66,7 +66,7 @@ ynh_systemd_action --service_name="$app@$app" --action=start --line_match="Home 
 # remove --verbose from service and restart
 ynh_replace_string --match_string=" --verbose" --replace_string="" --target_file="/etc/systemd/system/$app@$app.service"
 systemctl daemon-reload
-ynh_systemd_action --service_name="$app@$app" --action=restart
+ynh_systemd_action --service_name="$app@$app" --action=restart --line_match="Started Home Assistant" --log_path="systemd" --timeout=3600
 
 ynh_script_progression --message="Restoring nginx web server..."
 ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"


### PR DESCRIPTION
## Problem

App is stuck at level 3 due to failing restore.
The CI tester is given a 502 Bad Gateway error after restoring the app.

## Solution
I have no idea why, since it works well in both my VM and my RPi.
- First test: wait for the service to tell us Home Assistant has been successfully restarted.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.
