### PR TITLE
Add logrotate

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -28,5 +28,6 @@ ynh_backup --src_path="$home_path"
 ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_backup --src_path="/etc/sudoers.d/$app"
 ynh_backup --src_path="/etc/systemd/system/$app@$app.service"
+ynh_backup --src_path="/etc/logrotate.d/$app"
 
 ynh_print_info --message="Backup of $app completed"

--- a/scripts/install
+++ b/scripts/install
@@ -77,6 +77,9 @@ ynh_store_file_checksum --file="/etc/systemd/system/$app@$app.service"
 systemctl daemon-reload
 ynh_systemd_action --service_name="$app@$app" --action=restart
 
+# enable logrotate
+ynh_use_logrotate --logfile="$data_path/home-assistant.log"
+
 # create a dedicated nginx config
 ynh_script_progression --message="Configuring nginx web server..."
 ynh_add_nginx_config

--- a/scripts/remove
+++ b/scripts/remove
@@ -36,6 +36,9 @@ ynh_systemd_action --service_name="$app@$app" --action=stop
 ynh_systemd_action --service_name="$app@$app" --action=disable
 ynh_secure_remove --file="/etc/systemd/system/$app@$app.service"
 
+# remove logrotate config
+ynh_remove_logrotate
+
 # close port
 ynh_exec_fully_quiet yunohost firewall disallow TCP $port
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -61,7 +61,7 @@ yunohost service add "$app@$app" --log "$data_path/home-assistant.log" --descrip
 ynh_script_progression --message="Starting the Home Assistant server..."
 # add --verbose to service
 sed --in-place "/ExecStart/s/$/ --verbose/" "/etc/systemd/system/$app@$app.service"
-# start 
+# start
 ynh_systemd_action --service_name="$app@$app" --action=start --line_match="Home Assistant initialized" --log_path="systemd" --timeout=3600
 # remove --verbose from service and restart
 ynh_replace_string --match_string=" --verbose" --replace_string="" --target_file="/etc/systemd/system/$app@$app.service"
@@ -70,6 +70,9 @@ ynh_systemd_action --service_name="$app@$app" --action=restart --line_match="Sta
 
 ynh_script_progression --message="Restoring nginx web server..."
 ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
+# restore logrotate
+ynh_restore_file --origin_path="/etc/logrotate.d/$app"
+
 # reload nginx
 ynh_systemd_action --service_name=nginx --action=reload
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -73,6 +73,9 @@ ynh_store_file_checksum --file="/etc/systemd/system/$app@$app.service"
 systemctl daemon-reload
 ynh_systemd_action --service_name="$app@$app" --action=restart
 
+# enable logrotate
+ynh_use_logrotate --logfile="$data_path/home-assistant.log" --nonappend
+
 # create a dedicated nginx config
 ynh_script_progression --message="Configuring nginx web server..."
 ynh_add_nginx_config


### PR DESCRIPTION
Currently my log in `/home/homeassistant/.homeassistant/home-assistant.log` takes 232M of space, which I find to be significant for a log file.

I suggest adding a `logrotate` config to manage properly its size.