### PR TITLE
Add "/api/" to "skipped_uris".

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -53,8 +53,6 @@ ynh_app_setting_set --app=$app --key=final_path --value="$final_path"
 ynh_app_setting_set --app=$app --key=data_path --value="$data_path"
 ynh_app_setting_set --app=$app --key=log_file --value="$log_file"
 ynh_app_setting_set --app=$app --key=path_url --value="$path_url"
-# Allow the web UI to use its own API without SSOWat interfering with it.
-ynh_app_setting_set --app=$app --key=skipped_uris --value="/api/"
 
 #=================================================
 # STANDARD MODIFICATIONS
@@ -186,7 +184,8 @@ ynh_systemd_action --service_name=$app --action=restart
 ynh_script_progression --message="Configuring permissions..."
 
 [ $is_public -eq 1 ] && ynh_permission_update --permission="main" --add="visitors"
-ynh_app_setting_set --app=$app --key=skipped_uris --value="/api/"
+# Allow the web UI to use its own API without Yunohost/SSOWat interfering with it. Home Assistant authentication should still be in effect.
+ynh_permission_create --permission="api" --label="api" --url="/api" --allowed="visitors" "all_users" --auth_header="false" --show_tile="false" --protected="true"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -53,6 +53,8 @@ ynh_app_setting_set --app=$app --key=final_path --value="$final_path"
 ynh_app_setting_set --app=$app --key=data_path --value="$data_path"
 ynh_app_setting_set --app=$app --key=log_file --value="$log_file"
 ynh_app_setting_set --app=$app --key=path_url --value="$path_url"
+# Allow the web UI to use its own API without SSOWat interfering with it.
+ynh_app_setting_set --app=$app --key=skipped_uris --value="/api/"
 
 #=================================================
 # STANDARD MODIFICATIONS
@@ -184,6 +186,7 @@ ynh_systemd_action --service_name=$app --action=restart
 ynh_script_progression --message="Configuring permissions..."
 
 [ $is_public -eq 1 ] && ynh_permission_update --permission="main" --add="visitors"
+ynh_app_setting_set --app=$app --key=skipped_uris --value="/api/"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,6 +32,16 @@ db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 upgrade_type=$(ynh_check_app_version_changed)
 
 #=================================================
+# ENSURE DOWNWARD COMPATIBILITY
+#=================================================
+ynh_script_progression --message="Ensuring downward compatibility..."
+
+# Create a permission if needed
+if ! ynh_permission_exists --permission="api"; then
+    ynh_permission_create --permission="api" --label="api" --url="/api" --allowed="visitors" "all_users" --auth_header="false" --show_tile="false" --protected="true"
+fi
+
+#=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================
 ynh_script_progression --message="Backing up the app before upgrading (may take a while)..."


### PR DESCRIPTION
Fixes https://github.com/YunoHost-Apps/homeassistant_ynh/issues/161

## Problem

See https://github.com/YunoHost-Apps/homeassistant_ynh/issues/161

## Solution

Setting this "ignored_uris" setting seems to fix it.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
