### PR TITLE
Add fail2ban support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Home automation platform",
         "fr": "Plateforme domotique"
     },
-    "version": "2023.1.7~ynh1",
+    "version": "2023.1.7~ynh2",
     "url": "https://github.com/home-assistant/home-assistant",
     "upstream": {
         "license": "Apache-2.0",

--- a/scripts/backup
+++ b/scripts/backup
@@ -59,6 +59,13 @@ ynh_backup --src_path="$data_path" --is_big
 ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
+# BACKUP FAIL2BAN CONFIGURATION
+#=================================================
+
+ynh_backup --src_path="/etc/fail2ban/jail.d/$app.conf"
+ynh_backup --src_path="/etc/fail2ban/filter.d/$app.conf"
+
+#=================================================
 # SPECIFIC BACKUP
 #=================================================
 # BACKUP LOGROTATE

--- a/scripts/install
+++ b/scripts/install
@@ -184,6 +184,14 @@ systemctl daemon-reload
 ynh_systemd_action --service_name=$app --action=restart
 
 #=================================================
+# SETUP FAIL2BAN
+#=================================================
+ynh_script_progression --message="Configuring Fail2Ban..." --weight=1
+
+# Create a dedicated Fail2Ban config
+ynh_add_fail2ban_config --logpath="$log_file" --failregex="Login attempt or request with invalid authentication from <HOST>"
+
+#=================================================
 # SETUP SSOWAT
 #=================================================
 ynh_script_progression --message="Configuring permissions..."

--- a/scripts/remove
+++ b/scripts/remove
@@ -92,6 +92,14 @@ ynh_script_progression --message="Removing dependencies..."
 ynh_remove_app_dependencies
 
 #=================================================
+# REMOVE FAIL2BAN CONFIGURATION
+#=================================================
+ynh_script_progression --message="Removing Fail2Ban configuration..." --weight=1
+
+# Remove the dedicated Fail2Ban config
+ynh_remove_fail2ban_config
+
+#=================================================
 # SPECIFIC REMOVE
 #=================================================
 # REMOVE VARIOUS FILES

--- a/scripts/restore
+++ b/scripts/restore
@@ -80,6 +80,15 @@ ynh_restore_file --origin_path="$data_path" --not_mandatory
 mkdir -p $data_path
 
 #=================================================
+# RESTORE FAIL2BAN CONFIGURATION
+#=================================================
+ynh_script_progression --message="Restoring the Fail2Ban configuration..." --weight=1
+
+ynh_restore_file --origin_path="/etc/fail2ban/jail.d/$app.conf"
+ynh_restore_file --origin_path="/etc/fail2ban/filter.d/$app.conf"
+ynh_systemd_action --action=restart --service_name=fail2ban
+
+#=================================================
 # SPECIFIC RESTORATION
 #=================================================
 # REINSTALL DEPENDENCIES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -113,6 +113,14 @@ ynh_script_progression --message="Upgrading systemd configuration..."
 ynh_add_systemd_config
 
 #=================================================
+# SETUP FAIL2BAN
+#=================================================
+ynh_script_progression --message="Reconfiguring Fail2Ban..." --weight=1
+
+# Create a dedicated Fail2Ban config
+ynh_add_fail2ban_config --logpath="$log_file" --failregex="Login attempt or request with invalid authentication from <HOST>"
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SETUP LOGROTATE


### PR DESCRIPTION
## Problem

- *Home assistant is installed publicly by default, and need to be for the mobile app to work. Therefor, it's open to brute force attacks on its login page.*

## Solution

- *Implement fail2ban to protect Home assistant.*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
