### PR TITLE
Add api permission

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -21,8 +21,11 @@ cpe = "cpe:2.3:a:home-assistant:home-assistant"
 yunohost = ">= 11.2"
 architectures = ["amd64", "arm64"]
 multi_instance = false
+
 ldap = true
+
 sso = false
+
 disk = "2G"
 ram.build = "2G"
 ram.runtime = "2G"
@@ -91,6 +94,10 @@ ram.runtime = "2G"
     
     [resources.permissions]
     main.url = "/"
+    api.url = "/api"
+    api.show_tile = false
+    api.allowed = "visitors"
+    api.auth_header = false
     
     [resources.ports]
     main.default = 8123

--- a/manifest.toml
+++ b/manifest.toml
@@ -21,11 +21,8 @@ cpe = "cpe:2.3:a:home-assistant:home-assistant"
 yunohost = ">= 11.2"
 architectures = ["amd64", "arm64"]
 multi_instance = false
-
 ldap = true
-
 sso = false
-
 disk = "2G"
 ram.build = "2G"
 ram.runtime = "2G"


### PR DESCRIPTION
## Problem

- In case of ha is not open to visitors : 
  - authenfication will be done by ssowat and then homeassitant authentification system
  - api can be accessed with a TOKEN but ssowat need to be bypassed

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
