### PR TITLE
Update manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -53,7 +53,7 @@ ram.runtime = "2G"
 
     [install.elevation]
     ask.en = "Altitude above sea level in meters. Impacts sunrise data."
-    type = "number"
+    type = "string"
     default = 430
 
     [install.unit_system]


### PR DESCRIPTION
modified elevatation from number to string due to an error of frontend

## Problem

- Installing HomeAssistant is not possible due to an error of Elevation that is compared to none value on frontend mode

## Solution

- Change the value of elevation from number to string, the installation is fine with this modification

## PR Status

- [ X ] Code finished and ready to be reviewed/tested
- [ X ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
