### PR TITLE
Do not create all users as admin

### DIFF
--- a/conf/homeassistant_conf_files/bin/ynh_ldap-auth.sh
+++ b/conf/homeassistant_conf_files/bin/ynh_ldap-auth.sh
@@ -26,9 +26,11 @@ USERNAME_PATTERN='^[a-z|A-Z|0-9|_|-|.]+$'
 # Adapt to your needs.
 SERVER="ldap://127.0.0.1:389"
 USERDN="uid=$username,ou=users,dc=yunohost,dc=org"
+GROUPDN="ou=groups,dc=yunohost,dc=org"
 BASEDN="$USERDN"
 SCOPE="base"
 FILTER="(&(uid=$username)(objectClass=posixAccount))"
+ADMINFILTER="(&(cn=admins)(memberUid=$username))"
 NAME_ATTR="cn"
 ATTRS="$ATTRS $NAME_ATTR"
 
@@ -63,11 +65,27 @@ ldap_auth_ldapsearch() {
 	return 0
 }
 
+is_in_admin_group() {
+	common_opts="-o nettimeout=$TIMEOUT -H $SERVER -x"
+	group_output=$(ldapsearch $common_opts -LLL \
+		-D "$USERDN" -w "$password" \
+		-b "$GROUPDN" \
+		"$ADMINFILTER" dn)
+	echo "$group_output" | grep -qi "^dn:" && return 0
+	return 1
+}
+
 on_auth_success() {
 	# print the meta entries for use in HA
 	if [ ! -z "$NAME_ATTR" ]; then
 		name=$(echo "$output" | sed -nr "s/^\s*$NAME_ATTR:\s*(.+)\s*\$/\1/Ip")
 		[ -z "$name" ] || echo "name=$name"
+	fi
+
+	if is_in_admin_group; then
+		echo "group=system-admin"
+	else
+		echo "group=system-users"
 	fi
 }
 


### PR DESCRIPTION
## Problem
All users are created with admin privileges.

## Solution
Check if user is an admin group, if yes print "group=system-admin", else use "group=system-user'.
Home Assistant will use this directive to determine new account privileges (on creation only)

## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [ x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
